### PR TITLE
feat: add Gemini API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ pip install -e .
 ```
 
 
-## OpenAI API Key
+## API Key
 
-The Virtual Lab currently uses GPT-4o from OpenAI. Save your OpenAI API key as the environment variable `OPENAI_API_KEY`. For example, add `export OPENAI_API_KEY=<your_key>` to your `.bashrc` or `.bash_profile`.
+The Virtual Lab uses OpenAI models by default, but it can also run with Google's Gemini models through the OpenAI-compatible endpoint. Set one of the following environment variables:
+
+- `OPENAI_API_KEY` for OpenAI models
+- `GEMINI_API_KEY` for Gemini models
+
+If `GEMINI_API_KEY` is set, the code will automatically route requests to Gemini. For example, add `export GEMINI_API_KEY=<your_key>` to your `.bashrc` or `.bash_profile`.

--- a/src/virtual_lab/constants.py
+++ b/src/virtual_lab/constants.py
@@ -2,6 +2,9 @@
 
 DEFAULT_MODEL = "gpt-4o-2024-08-06"
 
+# Base URL for Gemini's OpenAI-compatible endpoint
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
 # Prices in USD as of January 18, 2025 (https://openai.com/api/pricing/)
 MODEL_TO_INPUT_PRICE_PER_TOKEN = {
     "gpt-3.5-turbo-0125": 0.5 / 10**6,
@@ -9,6 +12,9 @@ MODEL_TO_INPUT_PRICE_PER_TOKEN = {
     "gpt-4o-2024-05-13": 5 / 10**6,
     "gpt-4o-mini-2024-07-18": 0.15 / 10**6,
     "o1-mini-2024-09-12": 3 / 10**6,
+    # Gemini models
+    "gemini-1.5-flash": 35 / 10**6,
+    "gemini-1.5-pro": 350 / 10**6,
 }
 
 MODEL_TO_OUTPUT_PRICE_PER_TOKEN = {
@@ -17,6 +23,9 @@ MODEL_TO_OUTPUT_PRICE_PER_TOKEN = {
     "gpt-4o-2024-05-13": 15 / 10**6,
     "gpt-4o-mini-2024-07-18": 0.6 / 10**6,
     "o1-mini-2024-09-12": 12 / 10**6,
+    # Gemini models
+    "gemini-1.5-flash": 106 / 10**6,
+    "gemini-1.5-pro": 1050 / 10**6,
 }
 
 FINETUNING_MODEL_TO_INPUT_PRICE_PER_TOKEN = {

--- a/src/virtual_lab/run_meeting.py
+++ b/src/virtual_lab/run_meeting.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from openai import OpenAI
 from tqdm import trange, tqdm
 
 from virtual_lab.agent import Agent
@@ -24,6 +23,7 @@ from virtual_lab.utils import (
     convert_messages_to_discussion,
     count_discussion_tokens,
     count_tokens,
+    get_client,
     get_messages,
     get_summary,
     print_cost_and_time,
@@ -91,8 +91,8 @@ def run_meeting(
     # Start timing the meeting
     start_time = time.time()
 
-    # Set up client
-    client = OpenAI()
+    # Set up client (OpenAI or Gemini depending on environment variable)
+    client = get_client()
 
     # Set up team
     if meeting_type == "team":

--- a/src/virtual_lab/utils.py
+++ b/src/virtual_lab/utils.py
@@ -1,6 +1,7 @@
 """Contains useful utility functions."""
 
 import json
+import os
 import urllib.parse
 from pathlib import Path
 
@@ -15,8 +16,27 @@ from virtual_lab.constants import (
     MODEL_TO_OUTPUT_PRICE_PER_TOKEN,
     FINETUNING_MODEL_TO_TRAINING_PRICE_PER_TOKEN,
     PUBMED_TOOL_NAME,
+    GEMINI_BASE_URL,
 )
 from virtual_lab.prompts import format_references
+
+
+def get_client() -> OpenAI:
+    """Return an OpenAI client for either OpenAI or Gemini."""
+
+    gemini_key = os.getenv("GEMINI_API_KEY")
+    if gemini_key:
+        return OpenAI(api_key=gemini_key, base_url=GEMINI_BASE_URL)
+    return OpenAI()
+
+
+def get_async_client() -> AsyncOpenAI:
+    """Return an AsyncOpenAI client for either OpenAI or Gemini."""
+
+    gemini_key = os.getenv("GEMINI_API_KEY")
+    if gemini_key:
+        return AsyncOpenAI(api_key=gemini_key, base_url=GEMINI_BASE_URL)
+    return AsyncOpenAI()
 
 
 def get_pubmed_central_article(


### PR DESCRIPTION
## Summary
- allow using a `GEMINI_API_KEY` that points the client to Google's OpenAI-compatible Gemini endpoint
- include Gemini models in pricing constants
- document how to configure Gemini in README

## Testing
- `python -m compileall -q src/virtual_lab`


------
https://chatgpt.com/codex/tasks/task_e_68afba902ba8832e82f67de83a7ef1bd